### PR TITLE
ci: remove n8n webhook notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,14 +81,3 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_GihubIntegratedServices }}
           HUSKY: 0
 
-      - name: Wait 10 minutes
-        run: sleep 600
-
-      - name: Send HTTP request after publish
-        run: |
-          curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"package": "ch-chat-api-typescript-axios"}' \
-            https://n8n.icloudhospital.com/webhook/github-api-release
-


### PR DESCRIPTION
## Summary

Remove the 10-minute sleep and n8n webhook HTTP request after NPM publish.

## Changes

- Removed `Wait 10 minutes` step (sleep 600)
- Removed `Send HTTP request after publish` step (curl to n8n webhook)